### PR TITLE
Net framework version update to development

### DIFF
--- a/spreadsheet-creator/spreadsheet-creator.csproj
+++ b/spreadsheet-creator/spreadsheet-creator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>spreadsheet_creator</RootNamespace>
   </PropertyGroup>
 

--- a/spreadsheet-creator/spreadsheet-creator.csproj
+++ b/spreadsheet-creator/spreadsheet-creator.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="SpreadsheetLight" Version="3.5.0" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.2" />
+    <PackageReference Include="System.IO.Packaging" Version="10.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Merging .Net framework target changes from version 8 to version 10 and libraries used by SpreadsheetLight transitively changes to avoid vulnerabilities to development branch since I merged directly to master by mistake